### PR TITLE
Fix Tmux Config Parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,9 +243,9 @@ checksum = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "list"
@@ -602,9 +602,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "yaml-rust"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]

--- a/load/Cargo.toml
+++ b/load/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 common    = { path = "../common" }
 dirs      = "2.0.2"
 libc      = "0.2.66"
-yaml-rust = { version = "0.4.3", default-features = false }
+yaml-rust = { version = "0.4.5", default-features = false }
 
 [dev-dependencies]
 rand      = "0.7.2"

--- a/load/src/tmux/config.rs
+++ b/load/src/tmux/config.rs
@@ -21,7 +21,7 @@ impl Config {
 
         for line in lines {
             let opt: Vec<&str> = line.split(' ').collect();
-            config.insert(opt[0], opt[1]);
+            config.insert(opt[0], opt.get(1).unwrap_or(&""));
         }
 
         Config {

--- a/load/src/tmux/config.rs
+++ b/load/src/tmux/config.rs
@@ -55,7 +55,8 @@ fn expect_missing_base_index_0() {
 
 #[test]
 fn expect_pane_base_index_0() {
-    let output = "some-stuff false\npane-base-index 0\nother-thing true".to_string();
+    let output =
+        "some-stuff false\npane-base-index 0\nother-thing true\nvalue-less-option".to_string();
     let config = Config::from_string(output);
     assert_eq!(config.pane_base_index, 0)
 }


### PR DESCRIPTION
I was running into issues with parsing the Tmux config after a tmux upgrade. Unfortunately I didn't record the version I was upgrading too, for documentation

What I found when digging in was that tmux was reporting a config option that did not have a value. This was breaking the config parsing in `muxed`.
Since muxed only actually checks for a few config options, and not the value less ones I was finding. The easiest fix seemed to be to default to an empty string value in this case, which this PR implements!
